### PR TITLE
feat: add camera follow script and tag level walls

### DIFF
--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -1928,6 +1928,7 @@ GameObject:
   - component: {fileID: 330585545}
   - component: {fileID: 330585544}
   - component: {fileID: 330585547}
+  - component: {fileID: 330585548}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -2053,6 +2054,21 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!114 &330585548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330585543}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f71bd302536340bf90a549a82a2adca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 2142426494}
+  offset: {x: 0, y: 30, z: -10}
+  smoothSpeed: 1
 --- !u!1001 &382596367
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4067,6 +4083,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2204552607313208138, guid: 7fdbd076ee75a4b21ae778c47c39db3e, type: 3}
       propertyPath: m_PlayOnAwake
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204552607316143946, guid: 7fdbd076ee75a4b21ae778c47c39db3e, type: 3}
+      propertyPath: m_Interpolate
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2204552607318958738, guid: 7fdbd076ee75a4b21ae778c47c39db3e, type: 3}

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -129,7 +129,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (62)
+      value: Brick Wall (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -728,7 +732,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (67)
+      value: Brick Wall (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -786,6 +794,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -903,7 +915,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (64)
+      value: Brick Wall (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -961,6 +977,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1078,7 +1098,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (82)
+      value: Brick Wall (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1135,7 +1159,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (70)
+      value: Brick Wall (27)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1250,6 +1278,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1448,7 +1480,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (73)
+      value: Brick Wall (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1564,6 +1600,7 @@ GameObject:
   - component: {fileID: 373890846}
   - component: {fileID: 373890845}
   - component: {fileID: 373890848}
+  - component: {fileID: 373890849}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1689,6 +1726,21 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!114 &373890849
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373890844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f71bd302536340bf90a549a82a2adca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 667587709}
+  offset: {x: 0, y: 30, z: -10}
+  smoothSpeed: 1
 --- !u!1001 &386808514
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1783,6 +1835,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1949,6 +2005,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2574,7 +2634,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (75)
+      value: Brick Wall (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2972,6 +3036,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2204552607313208138, guid: 7fdbd076ee75a4b21ae778c47c39db3e, type: 3}
       propertyPath: m_PlayOnAwake
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204552607316143946, guid: 7fdbd076ee75a4b21ae778c47c39db3e, type: 3}
+      propertyPath: m_Interpolate
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2204552607318958738, guid: 7fdbd076ee75a4b21ae778c47c39db3e, type: 3}
@@ -3389,7 +3457,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (79)
+      value: Brick Wall (29)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3503,7 +3575,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (72)
+      value: Brick Wall (25)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3561,6 +3637,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3871,7 +3951,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (58)
+      value: Brick Wall (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3985,7 +4069,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (78)
+      value: Brick Wall (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4270,7 +4358,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (71)
+      value: Brick Wall (26)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4384,7 +4476,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (66)
+      value: Brick Wall (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4498,7 +4594,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (74)
+      value: Brick Wall (24)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4613,6 +4713,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4730,7 +4834,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (76)
+      value: Brick Wall (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4844,7 +4952,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (84)
+      value: Brick Wall (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4959,6 +5071,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5140,7 +5256,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (80)
+      value: Brick Wall (28)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5691,7 +5811,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (68)
+      value: Brick Wall (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5749,6 +5873,10 @@ PrefabInstance:
     - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_Name
       value: Grass (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
       objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6333,7 +6461,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (65)
+      value: Brick Wall (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6587,6 +6719,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Grass (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
+      objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 27.6
@@ -6646,7 +6782,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (83)
+      value: Brick Wall (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6703,7 +6843,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (87)
+      value: Brick Wall (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6760,7 +6904,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (61)
+      value: Brick Wall (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6817,7 +6965,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (81)
+      value: Brick Wall (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7356,6 +7508,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Grass (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
+      objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 27.6
@@ -7664,6 +7820,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Grass (7)
       objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
+      objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 19.6
@@ -7780,7 +7940,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (86)
+      value: Brick Wall (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7837,7 +8001,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (77)
+      value: Brick Wall (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8546,7 +8714,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (63)
+      value: Brick Wall (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8603,7 +8775,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (69)
+      value: Brick Wall (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8768,6 +8944,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Grass
       objectReference: {fileID: 0}
+    - target: {fileID: 186118, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
+      propertyPath: m_TagString
+      value: Grass
+      objectReference: {fileID: 0}
     - target: {fileID: 494792, guid: 22c6a8a4101aacb4fa2b6d067faf99b0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 27.6
@@ -8827,7 +9007,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (88)
+      value: Brick Wall (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9143,7 +9327,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_Name
-      value: Brick (85)
+      value: Brick Wall (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 123996, guid: d65002cb2df73b749a881132d5483f89, type: 3}
+      propertyPath: m_TagString
+      value: Wall 1
       objectReference: {fileID: 0}
     - target: {fileID: 409900, guid: d65002cb2df73b749a881132d5483f89, type: 3}
       propertyPath: m_LocalPosition.x
@@ -9199,15 +9387,6 @@ SceneRoots:
   - {fileID: 408515008}
   - {fileID: 1377989874}
   - {fileID: 513524774}
-  - {fileID: 883438592}
-  - {fileID: 869412455}
-  - {fileID: 1790352671}
-  - {fileID: 1563908294}
-  - {fileID: 938873196}
-  - {fileID: 1524661181}
-  - {fileID: 556974215}
-  - {fileID: 965375008}
-  - {fileID: 887824919}
   - {fileID: 832128522}
   - {fileID: 1501047573}
   - {fileID: 1300765830}
@@ -9224,9 +9403,9 @@ SceneRoots:
   - {fileID: 2020849960}
   - {fileID: 1494354980}
   - {fileID: 1776566035}
-  - {fileID: 2104202892}
   - {fileID: 483300}
   - {fileID: 365831214}
+  - {fileID: 2104202892}
   - {fileID: 1778833361}
   - {fileID: 850554432}
   - {fileID: 997637173}
@@ -9237,6 +9416,15 @@ SceneRoots:
   - {fileID: 313619651}
   - {fileID: 1061286115}
   - {fileID: 708298127}
+  - {fileID: 883438592}
+  - {fileID: 869412455}
+  - {fileID: 1790352671}
+  - {fileID: 1563908294}
+  - {fileID: 938873196}
+  - {fileID: 1524661181}
+  - {fileID: 556974215}
+  - {fileID: 965375008}
+  - {fileID: 887824919}
   - {fileID: 503417996}
   - {fileID: 2084331832}
   - {fileID: 224742109}
@@ -9287,6 +9475,7 @@ SceneRoots:
   - {fileID: 138341305}
   - {fileID: 634795213}
   - {fileID: 702073754}
+  - {fileID: 449225495}
   - {fileID: 1697537872}
   - {fileID: 1079113970}
   - {fileID: 825466576}
@@ -9308,7 +9497,6 @@ SceneRoots:
   - {fileID: 959199814}
   - {fileID: 1719988084}
   - {fileID: 1038354211}
-  - {fileID: 449225495}
   - {fileID: 17467528}
   - {fileID: 1861160544}
   - {fileID: 667587706}

--- a/Assets/Scripts/CameraFollow.cs
+++ b/Assets/Scripts/CameraFollow.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+public class CameraFollow : MonoBehaviour
+{
+    public Transform target;      
+    public Vector3 offset;        // Position offset from the player
+    public float smoothSpeed = 0.125f;
+
+    void LateUpdate()
+    {
+        if (target == null) return;
+
+        // Desired camera position
+        Vector3 desiredPosition = target.position + offset;
+
+        // Smooth movement
+        Vector3 smoothedPosition = Vector3.Lerp(transform.position,
+                                                desiredPosition,
+                                                smoothSpeed);
+
+        transform.position = smoothedPosition;
+
+        // Keep camera looking at the player
+        transform.LookAt(target);
+    }
+}

--- a/Assets/Scripts/CameraFollow.cs.meta
+++ b/Assets/Scripts/CameraFollow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f71bd302536340bf90a549a82a2adca

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - Wall 1
   - Enemy
   - Teleport
+  - Grass
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
feat: add camera follow script and tag level walls

- Added CameraFollow script using Vector3.SmoothDamp for steadier motion
- Adjusted smoothTime to ~1s to reduce collision jitter
- Enabled Rigidbody interpolation on the player for smoother target movement
- Kept follow logic in LateUpdate for proper order after physics updates
- Tuned default offset to (0,30,-10) for better viewing angle
- Added tags to brick walls to be destructible in level 2